### PR TITLE
Fire callback CB_MAPQUEUE_CHANGED on /replay

### DIFF
--- a/core/Maps/MapQueue.php
+++ b/core/Maps/MapQueue.php
@@ -223,8 +223,8 @@ class MapQueue implements CallbackListener, CommandListener {
 			if (array_key_exists($map->uid, $this->queuedMaps)) {
 				unset($this->queuedMaps[$map->uid]);
 			}
-
 			array_unshift($this->queuedMaps, array($player, $map, true));
+			$this->maniaControl->callbackManager->triggerCallback(self::CB_MAPQUEUE_CHANGED, array('add', $map));
 		}
 	}
 


### PR DESCRIPTION
Needed this for to fix some weird behaviours in my "NextMap" widget in Plugin BWP\InfoWidgets and think it's useful for all plugin developers.