### PR TITLE
Reformat time_elapsed_string into camelcase. Database can be used with no password given

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-/.idea/
+.idea
+*.iml
+
 /configs/server.xml
 /logs/
 /ManiaControl.log

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -30,6 +30,30 @@
           <option name="ALIGN_CLASS_CONSTANTS" value="true" />
           <option name="PHPDOC_USE_FQCN" value="true" />
         </PHPCodeStyleSettings>
+        <DBN-PSQL>
+          <case-options enabled="false">
+            <option name="KEYWORD_CASE" value="lower" />
+            <option name="FUNCTION_CASE" value="lower" />
+            <option name="PARAMETER_CASE" value="lower" />
+            <option name="DATATYPE_CASE" value="lower" />
+            <option name="OBJECT_CASE" value="preserve" />
+          </case-options>
+          <formatting-settings enabled="false" />
+        </DBN-PSQL>
+        <DBN-SQL>
+          <case-options enabled="false">
+            <option name="KEYWORD_CASE" value="lower" />
+            <option name="FUNCTION_CASE" value="lower" />
+            <option name="PARAMETER_CASE" value="lower" />
+            <option name="DATATYPE_CASE" value="lower" />
+            <option name="OBJECT_CASE" value="preserve" />
+          </case-options>
+          <formatting-settings enabled="false">
+            <option name="STATEMENT_SPACING" value="one_line" />
+            <option name="CLAUSE_CHOP_DOWN" value="chop_down_if_statement_long" />
+            <option name="ITERATION_ELEMENTS_WRAPPING" value="chop_down_if_not_single" />
+          </formatting-settings>
+        </DBN-SQL>
         <XML>
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>

--- a/core/Database/Config.php
+++ b/core/Database/Config.php
@@ -42,7 +42,7 @@ class Config {
 	 * @return bool
 	 */
 	public function validate() {
-		if (!$this->host || !$this->port || !$this->user || !$this->pass || !$this->name) {
+		if (!$this->host || !$this->port || !$this->user || !$this->name) {
 			return false;
 		}
 		if ($this->user === 'mysql_user' || $this->pass === 'mysql_password') {

--- a/core/ManiaExchange/ManiaExchangeList.php
+++ b/core/ManiaExchange/ManiaExchangeList.php
@@ -204,7 +204,7 @@ class ManiaExchangeList implements CallbackListener, ManialinkPageAnswerListener
 				$lineQuad->setZ(0.001);
 			}
 
-			$time        = Formatter::time_elapsed_string(strtotime($map->updated));
+			$time        = Formatter::timeElapsedString(strtotime($map->updated));
 			$array       = array('$s' . $map->id => $posX + 3.5, '$s' . $map->name => $posX + 12.5, '$s' . $map->author => $posX + 59, '$s' . str_replace('Arena', '', $map->maptype) => $posX + 103, '$s' . $map->mood => $posX + 118, '$s' . $time => $posX + 130);
 			$labels      = $this->maniaControl->getManialinkManager()->labelLine($mapFrame, $array);
 			$authorLabel = $labels[2];

--- a/core/Utils/Formatter.php
+++ b/core/Utils/Formatter.php
@@ -48,24 +48,36 @@ abstract class Formatter {
 	/**
 	 * Format an elapsed time String (2 days ago...) by a given timestamp
 	 *
-	 * @param int $ptime
-	 * @return string
+	 * @param int $time Input time
+	 * @param boolean $short Short version
+	 * @return string Formatted elapsed time string
 	 */
-	public static function time_elapsed_string($ptime) {
-		// TODO: refactor code: camelCase!
-		$etime = time() - $ptime;
+	public static function timeElapsedString($time, $short = false) {
+		$elapsedTime = time() - $time;
 
-		if ($etime < 1) {
-			return '0 seconds';
+		$second =   $short ? 'sec.' : 'second';
+		$minute =   $short ? 'min.' : 'minute';
+		$hour =     $short ? 'h' : 'hour';
+		$day =      $short ? 'd' : 'day';
+		$month =    $short ? 'm' : 'month';
+		$year =     $short ? 'y' : 'year';
+
+		if ($elapsedTime < 1) {
+			return $short ? '0 sec.' : '0 seconds';
 		}
 
-		$a = array(12 * 30 * 24 * 60 * 60 => 'year', 30 * 24 * 60 * 60 => 'month', 24 * 60 * 60 => 'day', 60 * 60 => 'hour', 60 => 'minute', 1 => 'second');
+		$calculateSeconds = array(12 * 30 * 24 * 60 * 60 => $year,
+		                          30 * 24 * 60 * 60 => $month,
+		                          24 * 60 * 60 => $day,
+		                          60 * 60 => $hour,
+		                          60 => $minute,
+		                          1 => $second);
 
-		foreach ($a as $secs => $str) {
-			$d = $etime / $secs;
+		foreach ($calculateSeconds as $secs => $str) {
+			$d = $elapsedTime / $secs;
 			if ($d >= 1) {
 				$r = round($d);
-				return $r . ' ' . $str . ($r > 1 ? 's' : '') . ' ago';
+				return $r . ' ' . $str . ($r > 1 ? (!$short ? 's' : '') : '') . ' ago';
 			}
 		}
 		return '';


### PR DESCRIPTION
There are 2 main changes in the pull request:

- [x] The Formatter::time_elapsed_string is now refactored. (CamelCase)
- [x] The elapsed time formatter now also got an option to get the small edition (not yet usefull but maybe later on).
- [x] server.xml no longer requires a filled in password for the database. Some databases don't require passwords. (the null check is done anywere else).

Basic tests are done (checking /mxlist. Test on: php 5.6, TMCanyon).