### PR TITLE
Improve paging in map manager

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+###v0.259###
+#Changes
+- Improve paging in map manager, for when there are more than 3 pages of results
+- Change implemnented by Nactik
+
 ###v0.258###
 #Changes
 - MC compatibility with MX v2 api

--- a/core/ManiaControl.php
+++ b/core/ManiaControl.php
@@ -55,7 +55,7 @@ class ManiaControl implements CallbackListener, CommandListener, TimerListener, 
 	/*
 	 * Constants
 	 */
-	const VERSION                     = '0.258';
+	const VERSION                     = '0.259';
 	const API_VERSION                 = '2013-04-16';
 	const MIN_DEDIVERSION             = '2017-05-03_21_00';
 	const SCRIPT_TIMEOUT              = 40;

--- a/core/Maps/MapList.php
+++ b/core/Maps/MapList.php
@@ -67,6 +67,8 @@ class MapList implements ManialinkPageAnswerListener, CallbackListener {
 	/** @var ManiaControl $maniaControl */
 	private $maniaControl = null;
 
+	/** @var Array(Map) $searchedMapList */
+	private $searchedMapList = null;
 	/**
 	 * Construct a new map list instance
 	 *
@@ -140,11 +142,15 @@ class MapList implements ManialinkPageAnswerListener, CallbackListener {
 
 		// Get Maps
 		if (!is_array($mapList)) {
+			$this->searchedMapList = null;
 			$mapList = $this->maniaControl->getMapManager()->getMaps();
+		} else {
+			//Store the mapList for paging
+			$this->searchedMapList = $mapList; 
 		}
+		$totalMapsCount = count($mapList);
 		$mapList = array_slice($mapList, $mapsBeginIndex, self::MAX_PAGES_PER_CHUNK * self::MAX_MAPS_PER_PAGE);
 
-		$totalMapsCount = $this->maniaControl->getMapManager()->getMapsCount();
 		$pagesCount     = ceil($totalMapsCount / self::MAX_MAPS_PER_PAGE);
 
 		// Create ManiaLink
@@ -655,7 +661,7 @@ class MapList implements ManialinkPageAnswerListener, CallbackListener {
 				if (substr($actionId, 0, strlen(self::ACTION_PAGING_CHUNKS)) === self::ACTION_PAGING_CHUNKS) {
 					// Paging chunks
 					$neededPage = (int) substr($actionId, strlen(self::ACTION_PAGING_CHUNKS));
-					$this->showMapList($player, null, $neededPage - 1);
+					$this->showMapList($player, $this->searchedMapList, $neededPage - 1);
 				}
 				break;
 		}


### PR DESCRIPTION
Change tested on my servers and doesnt seem to break anything, but servers dont have a large maplist where the core issue exists.
It should fix problems with paging on map search when there are more than 2 pages of results