### PR TITLE
Fix ManiaExchange API v2 (MXList issues)

### DIFF
--- a/core/ManiaExchange/MXMapInfo.php
+++ b/core/ManiaExchange/MXMapInfo.php
@@ -39,13 +39,11 @@ class MXMapInfo {
 
 		if ($this->prefix === 'tm') {
 			$this->dir = 'tracks';
-			$this->id  = $mx->TrackID;
-			$this->uid = isset($mx->TrackUID) ? $mx->TrackUID : '';
 		} else {
 			$this->dir = 'maps';
-			$this->id  = $mx->MapID;
-			$this->uid = isset($mx->TrackUID) ? $mx->TrackUID : ''; // TODO: fix when migrating to new api; TrackUID is equal to MapUID
 		}
+		$this->id  = $mx->MapId;
+		$this->uid = $mx->MapUid;
 
 		if (!isset($mx->GbxMapName) || $mx->GbxMapName === '?') {
 			$this->name = $mx->Name;
@@ -53,39 +51,49 @@ class MXMapInfo {
 			$this->name = Formatter::stripDirtyCodes($mx->GbxMapName);
 		}
 
-		$this->userid      = $mx->UserID;
-		$this->author      = $mx->Username;
-		$this->uploaded    = $mx->UploadedAt;
-		$this->updated     = $mx->UpdatedAt;
-		$this->type        = $mx->TypeName;
+		//Searching for authors can slow down queries, it may be worth using only the uploader as the author ?
+		if (isset($mx->Authors[0]->User)) {
+			$this->userid      = $mx->Authors[0]->User->UserId;
+			$this->author      = $mx->Authors[0]->User->Name;
+		} else {
+			$this->userid      = $mx->Uploader->UserId;
+			$this->author      = $mx->Uploader->Name;
+		}
+
+		$this->uploaded    = isset($mx->UploadedAt) ? $mx->UploadedAt : '';
+		$this->updated     = isset($mx->UpdatedAt) ? $mx->UpdatedAt : '';
+		$this->type        = isset($mx->Type) ? $mx->Type : '';
 		$this->maptype     = isset($mx->MapType) ? $mx->MapType : '';
 		$this->titlepack   = isset($mx->TitlePack) ? $mx->TitlePack : '';
-		$this->style       = isset($mx->StyleName) ? $mx->StyleName : '';
-		$this->envir       = $mx->EnvironmentName;
+		$this->style       = isset($mx->Style) ? $mx->Style : ''; //todo: get name
+		$this->envir       = $mx->Environment;
 		$this->mood        = $mx->Mood;
-		$this->dispcost    = $mx->DisplayCost;
-		$this->lightmap    = $mx->Lightmap;
+		$this->dispcost    = isset($mx->DisplayCost) ? $mx->DisplayCost : '';
 		$this->modname     = isset($mx->ModName) ? $mx->ModName : '';
-		$this->exever      = $mx->ExeVersion;
-		$this->exebld      = $mx->ExeBuild;
-		$this->routes      = isset($mx->RouteName) ? $mx->RouteName : '';
-		$this->length      = isset($mx->LengthName) ? $mx->LengthName : '';
-		$this->unlimiter   = isset($mx->UnlimiterRequired) ? $mx->UnlimiterRequired : false;
+		$this->exever      = isset($mx->ExeVersion) ? $mx->ExeVersion : '';
+		$this->exebld      = isset($mx->Exebuild) ? $mx->Exebuild : '';
+		$this->length      = isset($mx->Length) ? $mx->Length : '';
 		$this->laps        = isset($mx->Laps) ? $mx->Laps : 0;
-		$this->difficulty  = $mx->DifficultyName;
-		$this->lbrating    = isset($mx->LBRating) ? $mx->LBRating : 0;
-		$this->trkvalue    = isset($mx->TrackValue) ? $mx->TrackValue : 0;
-		$this->replaytyp   = isset($mx->ReplayTypeName) ? $mx->ReplayTypeName : '';
-		$this->replayid    = isset($mx->ReplayWRID) ? $mx->ReplayWRID : 0;
+		$this->difficulty  = $mx->Difficulty;
+		$this->replaytyp   = isset($mx->ReplayType) ? $mx->ReplayType : '';
+		$this->replayid    = isset($mx->ReplayWR->ReplayId) ? $mx->ReplayWR->ReplayId : 0;
 		$this->replaycnt   = isset($mx->ReplayCount) ? $mx->ReplayCount : 0;
 		$this->awards      = isset($mx->AwardCount) ? $mx->AwardCount : 0;
 		$this->vehicleName = isset($mx->VehicleName) ? $mx->VehicleName : '';
+		$this->authorComment = isset($mx->Comments) ? $mx->AuthorComments : '';
+		$this->commentCount  = isset($mx->CommentCount) ? $mx->CommentCount : 0;
 
-		$this->authorComment = $mx->Comments;
-		$this->commentCount  = $mx->CommentCount;
 
-		$this->ratingVoteCount   = isset($mx->RatingVoteCount) ? $mx->RatingVoteCount : 0;
-		$this->ratingVoteAverage = isset($mx->RatingVoteAverage) ? $mx->RatingVoteAverage : 0;
+		//This fields are not available in MX API v2 : =========
+		$this->trkvalue    			= 0;
+		$this->lightmap    			= '';
+		$this->routes      			= '';
+		$this->unlimiter   			= false;
+		$this->lbrating    			= 0;
+		$this->ratingVoteCount   	= 0;
+		$this->ratingVoteAverage 	= 0;
+		//=====================================================
+
 
 		if (!$this->trkvalue && $this->lbrating > 0) {
 			$this->trkvalue = $this->lbrating;
@@ -94,16 +102,14 @@ class MXMapInfo {
 		}
 
 		$this->pageurl     = 'https://' . $this->prefix . '.mania-exchange.com/' . $this->dir . '/view/' . $this->id;
-		$this->downloadurl = 'https://' . $this->prefix . '.mania-exchange.com/' . $this->dir . '/download/' . $this->id;
+		$this->downloadurl = 'https://' . $this->prefix . '.mania-exchange.com/mapgbx/' . $this->id;
 
-		if ($mx->HasScreenshot) {
-			$this->imageurl = 'https://' . $this->prefix . '.mania-exchange.com/' . $this->dir . '/screenshot/normal/' . $this->id;
-		} else {
-			$this->imageurl = '';
-		}
+		//No screenshot available in MX API v2
+		$this->imageurl = '';
+
 
 		if ($mx->HasThumbnail) {
-			$this->thumburl = 'https://' . $this->prefix . '.mania-exchange.com/' . $this->dir . '/thumbnail/' . $this->id;
+			$this->thumburl = 'https://' . $this->prefix . '.mania-exchange.com/' . 'mapthumb/' . $this->id;
 		} else {
 			$this->thumburl = '';
 		}


### PR DESCRIPTION
Here's a fix for map searches via MX since the removal of the latest routes from the MX v1 API.

I ignored some fields that are no longer provided by the new API, but these fields aren't the most important.

**Tested on multiple servers**

PS: Unfortunately, some lines are marked as modified, 
even though they're just indentation changes related to my PHP formatter 
(I couldn't do much about it, sorry).